### PR TITLE
Ignore extraneous HTML elements, they just result in blank slides.

### DIFF
--- a/jquery.nivo.slider.js
+++ b/jquery.nivo.slider.js
@@ -32,8 +32,8 @@
         slider.css('position','relative');
         slider.addClass('nivoSlider');
         
-        //Find our slider children
-        var kids = slider.children();
+        //Find our slider children, ignore extraneous HTML elements
+        var kids = slider.children("img,a");
         kids.each(function() {
             var child = $(this);
             var link = '';


### PR DESCRIPTION
Working with a legacy CMS that's inserting image map tags next to some images in the slider.  Simply ignoring irrelevant elements seems to work well.

See Issue #33 an example of other people running into this problem.  In this particular case, modifying the CMS is not an option.